### PR TITLE
Add new loading indicator - Foursquare

### DIFF
--- a/src/components/FourSquare/FourSquare.scss
+++ b/src/components/FourSquare/FourSquare.scss
@@ -1,0 +1,196 @@
+.d-i-b {
+    display: inline-block;
+}
+
+.foursquare-bounding-box {
+    box-sizing: border-box;
+    display: inline-block;
+    font-size: 16px;
+
+    .foursquare-loader {
+        height: 100px;
+        width: 100px;
+        &.small{
+            height:30px;
+            width:30px;
+            animation: expandsmall 1s linear infinite;
+        }
+        &.medium{
+            height:50px;
+            width:50px;
+            animation: expandmedium 1s linear infinite;
+        }
+        &.large{
+            height: 100px;
+            width: 100px;
+            animation: expandlarge 1s linear infinite;
+        }
+        position: relative;
+        font-size: 0.8em;
+        animation: expandlarge 1s linear infinite;
+        transform: rotate(45deg);
+        
+
+        
+
+        span{
+            position:absolute;
+            width:50px;
+            height:50px;
+            animation: square 1s both infinite;
+
+            &.small{
+                height:15px;
+                width:15px;
+            }
+            &.medium{
+                height:25px;
+                width:25px;
+            }
+            &.large{
+                height: 50px;
+                width: 50px;
+            }
+            &:nth-child(1) {
+                top: 0;
+                left: 0;
+                background-color: red;
+                
+            }
+    
+            &:nth-child(2) {
+                
+                top: 0;
+                right: 0;
+                background-color: blue;
+                
+            }
+    
+            &:nth-child(3) {
+               
+                bottom: 0;
+                left: 0;
+                background-color: yellow;
+                
+            }
+    
+            &:nth-child(4) {
+                
+                bottom: 0;
+                right: 0;
+                background-color: purple;
+                
+            }
+
+        }
+
+    }
+    
+}
+
+
+
+@keyframes expandlarge {
+    0% {
+        width: 100px;
+        height: 100px;
+    }
+
+    10% {
+        width: 100px;
+        height: 100px;
+    }
+
+    50% {
+        width: 150px;
+        height: 150px;
+    }
+
+    90% {
+        width: 100px;
+        height: 100px;
+    }
+
+    100% {
+        width: 100px;
+        height: 100px;
+    }
+}
+
+@keyframes expandmedium {
+    0% {
+        width: 50px;
+        height: 50px;
+    }
+
+    10% {
+        width: 50px;
+        height: 50px;
+    }
+
+    50% {
+        width: 80px;
+        height: 80px;
+    }
+
+    90% {
+        width: 50px;
+        height: 50px;
+    }
+
+    100% {
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes expandsmall {
+    0% {
+        width: 30px;
+        height: 30px;
+    }
+
+    10% {
+        width: 30px;
+        height: 30px;
+    }
+
+    50% {
+        width: 50px;
+        height: 50px;
+    }
+
+    90% {
+        width: 30px;
+        height: 30px;
+    }
+
+    100% {
+        width: 30px;
+        height: 30px;
+    }
+}
+
+@keyframes square {
+    0% {
+        transform: rotate(0deg);
+    }
+
+    10% {
+        transform: rotate(0deg);
+    }
+
+    50% {
+        transform: rotate(90deg);
+    }
+   
+
+    90% {
+        transform: rotate(90deg);
+    }
+
+    100% {
+        transform: rotate(90deg);
+    }
+
+}

--- a/src/components/FourSquare/FourSquare.scss
+++ b/src/components/FourSquare/FourSquare.scss
@@ -8,21 +8,21 @@
     font-size: 16px;
 
     .foursquare-loader {
-        height: 100px;
-        width: 100px;
+        height: 6.25em;
+        width: 6.25em;
         &.small{
-            height:30px;
-            width:30px;
+            height:1.875em;
+            width:1.875em;
             animation: expandsmall 1s linear infinite;
         }
         &.medium{
-            height:50px;
-            width:50px;
+            height:3.125em;
+            width:3.125em;
             animation: expandmedium 1s linear infinite;
         }
         &.large{
-            height: 100px;
-            width: 100px;
+            height: 6.25em;
+            width: 6.25em;
             animation: expandlarge 1s linear infinite;
         }
         position: relative;
@@ -35,21 +35,21 @@
 
         span{
             position:absolute;
-            width:50px;
-            height:50px;
+            width: 3.125em;;
+            height: 3.125em;
             animation: square 1s both infinite;
 
             &.small{
-                height:15px;
-                width:15px;
+                height:0.9375em;
+                width:0.9375em;
             }
             &.medium{
-                height:25px;
-                width:25px;
+                height:1.5625em;
+                width:1.5625em;
             }
             &.large{
-                height: 50px;
-                width: 50px;
+                height: 3.125em;
+                width: 3.125em;
             }
             &:nth-child(1) {
                 top: 0;
@@ -92,82 +92,82 @@
 
 @keyframes expandlarge {
     0% {
-        width: 100px;
-        height: 100px;
+        width: 6.25em;
+        height: 6.25em;
     }
 
     10% {
-        width: 100px;
-        height: 100px;
+        width: 6.25em;
+        height: 6.25em;
     }
 
     50% {
-        width: 150px;
-        height: 150px;
+        width: 9.375em;
+        height: 9.375em;
     }
 
     90% {
-        width: 100px;
-        height: 100px;
+        width: 6.25em;
+        height: 6.25em;
     }
 
     100% {
-        width: 100px;
-        height: 100px;
+        width: 6.25em;
+        height: 6.25em;
     }
 }
 
 @keyframes expandmedium {
     0% {
-        width: 50px;
-        height: 50px;
+        width: 3.125em;
+        height: 3.125em;
     }
 
     10% {
-        width: 50px;
-        height: 50px;
+        width: 3.125em;
+        height: 3.125em;
     }
 
     50% {
-        width: 80px;
-        height: 80px;
+        width: 5em;
+        height: 5em;
     }
 
     90% {
-        width: 50px;
-        height: 50px;
+        width: 3.125em;
+        height: 3.125em;
     }
 
     100% {
-        width: 50px;
-        height: 50px;
+        width: 3.125em;
+        height: 3.125em;
     }
 }
 
 @keyframes expandsmall {
     0% {
-        width: 30px;
-        height: 30px;
+        width: 1.875em;
+        height: 1.875em;
     }
 
     10% {
-        width: 30px;
-        height: 30px;
+        width: 1.875em;
+        height: 1.875em;
     }
 
     50% {
-        width: 50px;
-        height: 50px;
+        width: 3.125em;
+        height: 3.125em;
     }
 
     90% {
-        width: 30px;
-        height: 30px;
+        width: 1.875em;
+        height: 1.875em;
     }
 
     100% {
-        width: 30px;
-        height: 30px;
+        width: 1.875em;
+        height: 1.875em;
     }
 }
 

--- a/src/components/FourSquare/FourSquare.stories.tsx
+++ b/src/components/FourSquare/FourSquare.stories.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { FourSquare } from "./FourSquare";
+
+export default {
+  title: "rli/FourSquare",
+  component: FourSquare,
+} as ComponentMeta<typeof FourSquare>;
+
+const Template: ComponentStory<typeof FourSquare> = (args) => <FourSquare {...args} />;
+
+export const Primary = Template.bind({});
+
+export const Secondary = Template.bind({});
+Secondary.args = {
+  color: "#b7ac9a",
+  text: true
+};
+
+export const Small = Template.bind({});
+Small.args = {
+  size: "small",
+};
+
+export const Medium = Template.bind({});
+Medium.args = {
+  size: "medium",
+};
+
+export const Large = Template.bind({});
+Large.args = {
+  size: "large",
+};

--- a/src/components/FourSquare/FourSquare.tsx
+++ b/src/components/FourSquare/FourSquare.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { FourSquareProps } from "./FourSquare.types";
+import "./FourSquare.scss";
+
+export const FourSquare: React.FC<FourSquareProps> = (props) => {
+
+    let colors;
+
+    if (props?.colors && props?.colors?.length === 4) {
+        colors = props.colors;
+    } else {
+        colors = ["red", "blue", "green", "yellow"];
+    }
+    const size: string = props?.size || "";
+    
+    return (
+        <div className="d-i-b foursquare-bounding-box">
+            <div className={`d-i-b foursquare-loader ${size}`}>
+
+                <span className={`box1 ${size}`} style={{ backgroundColor: colors[0] }}></span>
+                <span className={`box2 ${size}`} style={{ backgroundColor: colors[1] }}></span>
+                <span className={`box3 ${size}`} style={{ backgroundColor: colors[2] }}></span>
+                <span className={`box4 ${size}`} style={{ backgroundColor: colors[3] }}></span>
+
+                
+            </div>
+        </div>
+    );
+}

--- a/src/components/FourSquare/FourSquare.tsx
+++ b/src/components/FourSquare/FourSquare.tsx
@@ -6,10 +6,14 @@ export const FourSquare: React.FC<FourSquareProps> = (props) => {
 
     let colors;
 
+    console.log(typeof props.colors);
     if (props?.colors && props?.colors?.length === 4) {
         colors = props.colors;
-    } else {
-        colors = ["red", "blue", "green", "yellow"];
+    } else if(props.colors && typeof props.colors === "string") {
+        colors = new Array(4).fill(props.colors);
+        
+    } else{
+        colors = new Array(4).fill("limegreen");
     }
     const size: string = props?.size || "";
     

--- a/src/components/FourSquare/FourSquare.types.ts
+++ b/src/components/FourSquare/FourSquare.types.ts
@@ -1,0 +1,5 @@
+import React from "react";
+export interface FourSquareProps {
+	colors?: string[4];
+	size?: "small" | "medium" | "large";
+}

--- a/src/components/FourSquare/FourSquare.types.ts
+++ b/src/components/FourSquare/FourSquare.types.ts
@@ -1,5 +1,5 @@
 import React from "react";
 export interface FourSquareProps {
-	colors?: string[4];
+	colors?: string | string[];
 	size?: "small" | "medium" | "large";
 }

--- a/src/components/FourSquare/index.ts
+++ b/src/components/FourSquare/index.ts
@@ -1,0 +1,1 @@
+export {FourSquare} from "./FourSquare";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,6 +3,7 @@ import { CircularProgress } from "./CircularProgress";
 export * from "./Atom";
 export * from "./Commet";
 export * from "./CircularProgress";
+export * from "./FourSquare";
 export * from "./Mosaic";
 export * from "./Riple";
 export * from "./Seek";


### PR DESCRIPTION
Closes #1 
New loading indicator that adds to the collection of existing indicators. I've omitted `text` prop in this indicator since the animation involves changing the width of the container, positioning the text relative to the container would make it change its position when the size of the container changes, giving a non-uniform UX, it is best advised that the developer add his/her own loading text below/above the indicator so that the position of the text stays intact. 
The modifiable props in this indicator include the `size`(small, medium & large) and `colors`(the color of each of the 4 squares).
Could you kindly add the `hacktoberfest-accepted` label to this PR, so that this PR is considered under the hacktoberfest contest? Thanks.